### PR TITLE
Limit size of sounds

### DIFF
--- a/ios/ScratchJr/src/RecordSound.m
+++ b/ios/ScratchJr/src/RecordSound.m
@@ -61,9 +61,9 @@ NSString *canRecord;
     NSError *err;
     NSDictionary *settings = [NSDictionary dictionaryWithObjectsAndKeys:
                               [NSNumber numberWithInt: kAudioFormatLinearPCM], AVFormatIDKey,
-                              [NSNumber numberWithFloat: 22050.0], AVSampleRateKey,
+                              [NSNumber numberWithFloat: 16000.0], AVSampleRateKey,
                               [NSNumber numberWithInt: 1], AVNumberOfChannelsKey,
-                              [NSNumber numberWithInt: 16], AVLinearPCMBitDepthKey,
+                              [NSNumber numberWithInt: 8], AVLinearPCMBitDepthKey,
                               nil];
     recorder = [[ AVAudioRecorder alloc] initWithURL:url settings:settings error:&err];
     if (err) {

--- a/src/editor/ui/Record.js
+++ b/src/editor/ui/Record.js
@@ -173,7 +173,7 @@ export default class Record {
                 if (isRecording) {
                     Record.stopRecording();
                 }
-            }, 60000);
+            }, 30000);
         }
     }
 


### PR DESCRIPTION
We know that projects with lots of (large) sounds tend to crash ScratchJr. Hopefully reducing the size of the sounds will help to reduce the number of crashes.