### PR TITLE
Revert balloon SVG to fix speech balloon bug

### DIFF
--- a/editions/free/src/assets/balloon.svg
+++ b/editions/free/src/assets/balloon.svg
@@ -1,1 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="30" height="44" viewBox="0 0 30 44"><path fill="#28A5DA" stroke="#FFF" stroke-miterlimit="10" d="M.5 6.5a6 6 0 0 1 6-6h17c3.312 0 6 2.687 6 6v24c0 3.312-2.688 6-6 6h-2l-7 7-7-7h-1c-3.313 0-6-2.688-6-6z"/></svg>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="30px" height="44px" viewBox="0 0 30 44">
+<path fill="#28A5DA" stroke="#FFFFFF" stroke-miterlimit="10" d="M0.5,6.5c0-3.313,2.687-6,6-6h17c3.312,0,6,2.687,6,6v24
+	c0,3.312-2.688,6-6,6h-2l-7,7l-7-7h-1c-3.313,0-6-2.688-6-6z"/>
+</svg>


### PR DESCRIPTION
drawBalloon for the sprite modifies the svg based on the size of the text. Reverted to the unoptimized SVG so that the pattern matching code works.