### PR TITLE
Don’t adjust paintEditor point on Android

### DIFF
--- a/src/painteditor/PaintAction.js
+++ b/src/painteditor/PaintAction.js
@@ -13,7 +13,7 @@ import SVGImage from './SVGImage';
 import Camera from './Camera';
 import Events from '../utils/Events';
 import Rectangle from '../geom/Rectangle';
-import {gn, isTablet, getIdFor} from '../utils/lib';
+import {gn, isTablet, isiOS, getIdFor} from '../utils/lib';
 /*
 Type of objects:
 - fixed: Only exists on Assets Backgrounds and can it only be fill (color or camera) or removed
@@ -1131,8 +1131,10 @@ export default class PaintAction {
         pt2.x = pt.x;
         pt2.y = pt.y;
         var globalPoint = pt2.matrixTransform(Paint.root.getScreenCTM().inverse());
-        globalPoint.x = globalPoint.x / Paint.currentZoom;
-        globalPoint.y = globalPoint.y / Paint.currentZoom;
+        if (isiOS) {
+            globalPoint.x = globalPoint.x / Paint.currentZoom;
+            globalPoint.y = globalPoint.y / Paint.currentZoom;
+        }
         return globalPoint;
     }
 }


### PR DESCRIPTION
Fixes #137 where the editor doesn’t draw where the finger is touching on Android.

### Testing
I did a quick test to make sure this worked on both an iPad and an Android tablet.  It will need much more testing to check that it's fine on a variety of tablets with different aspect ratios and versions of Android.

In a separate PR we should update to the latest SDKs and perhaps revise minimum OS version supported. 