### PR TITLE
Remove Events class in src/lobby/Home.js

### DIFF
--- a/src/lobby/Home.js
+++ b/src/lobby/Home.js
@@ -6,6 +6,7 @@ import Lobby from './Lobby';
 import iOS from '../iPad/iOS';
 import IO from '../iPad/IO';
 import Project from '../editor/ui/Project';
+import Events from '../utils/Events';
 import Localization from '../utils/Localization';
 import ScratchAudio from '../utils/ScratchAudio';
 import Vector from '../geom/Vector';
@@ -303,27 +304,5 @@ export default class Home {
         function drawMe (url) {
             img.src = url;
         }
-    }
-}
-
-class Events {
-    static getTargetPoint (e) {
-        if (isTablet) {
-            if (e.touches && (e.touches.length > 0)) {
-                return {
-                    x: e.touches[0].pageX,
-                    y: e.touches[0].pageY
-                };
-            } else if (e.changedTouches) {
-                return {
-                    x: e.changedTouches[0].pageX,
-                    y: e.changedTouches[0].pageY
-                };
-            }
-        }
-        return {
-            x: e.clientX,
-            y: e.clientY
-        };
     }
 }


### PR DESCRIPTION
Remove Events class in src/lobby/Home.js whose getTargetPoint is duplicated with src/utils/Events.js.
The getTargetPoint function in Events of Home.js is exactly the same with that in src/utils/Events.js.