### PR TITLE
Move build out of src folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /android/ScratchJr/app/src/main/gen/
 /node_modules
-/src/build/
+/build/
 .DS_Store
 *.iml
 .gradle

--- a/editions/free/src/app.bundle.js
+++ b/editions/free/src/app.bundle.js
@@ -1,1 +1,1 @@
-../../../src/build/bundles/app.bundle.js
+../../../build/bundles/app.bundle.js

--- a/editions/free/src/app.bundle.js.map
+++ b/editions/free/src/app.bundle.js.map
@@ -1,1 +1,1 @@
-../../../src/build/bundles/app.bundle.js.map
+../../../build/bundles/app.bundle.js.map

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
         app: './src/entry/app.js'
     },
     output: {
-        path: './src/build/bundles',
+        path: './build/bundles',
         filename: '[name].bundle.js'
     },
     module: {


### PR DESCRIPTION
I think build in src folder is not a good practice. When searching in src folder, a lot of build results come out. So why not move it out?