### PR TITLE
Fix Android (gradle) build error

### DIFF
--- a/android/ScratchJr/build.gradle
+++ b/android/ScratchJr/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.1'
@@ -18,9 +18,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 }


### PR DESCRIPTION
Builds that worked one day, suddenly fail the next. The error is:
`Could not find play-services-basement.aar (com.google.android.gms:play-services-basement:15.0.1).`

Re-ordering the repositories fixes the issue (from Stack Overflow):
https://stackoverflow.com/questions/50563407/could-not-find-play-services-basement-aar