### PR TITLE
revise minimum screen width

### DIFF
--- a/android/ScratchJr/.idea/misc.xml
+++ b/android/ScratchJr/.idea/misc.xml
@@ -27,7 +27,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/ScratchJr/app/src/main/AndroidManifest.xml
+++ b/android/ScratchJr/app/src/main/AndroidManifest.xml
@@ -11,8 +11,8 @@
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
-    
-    <supports-screens android:requiresSmallestWidthDp="500" />
+
+    <supports-screens android:requiresSmallestWidthDp="600" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
The previous change removed the legacy screen sizes, but left the `requiresSmallestWidthDp` at 500. According to https://developer.android.com/guide/topics/manifest/supports-screens-element#requiresSmallest, a 7-inch tablet corresponds to 600dp.