### PR TITLE
Revert paint change for android

### DIFF
--- a/src/painteditor/PaintAction.js
+++ b/src/painteditor/PaintAction.js
@@ -1131,10 +1131,8 @@ export default class PaintAction {
         pt2.x = pt.x;
         pt2.y = pt.y;
         var globalPoint = pt2.matrixTransform(Paint.root.getScreenCTM().inverse());
-        if (isiOS) {
-            globalPoint.x = globalPoint.x / Paint.currentZoom;
-            globalPoint.y = globalPoint.y / Paint.currentZoom;
-        }
+        globalPoint.x = globalPoint.x / Paint.currentZoom;
+        globalPoint.y = globalPoint.y / Paint.currentZoom;
         return globalPoint;
     }
 }


### PR DESCRIPTION
This didn’t fix the paint issue, just changed which kind of devices see the problem. Reverted the change to work for cheaper, regular density tablets.