### PR TITLE
revert ios scroll fix

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -226,17 +226,15 @@ export default class ScratchJr {
 
     static editorEvents () {
         document.ongesturestart = undefined;
+        document.ontouchmove = function (e) {
+            e.preventDefault();
+        };
         window.ontouchstart = ScratchJr.unfocus;
         if (isTablet) {
             window.ontouchend = undefined;
         } else {
             window.onmouseup = undefined;
         }
-        document.body.addEventListener('touchmove',
-            function (e) {
-                e.preventDefault();
-            },
-            {passive: false});
     }
 
     static unfocus (evt) {


### PR DESCRIPTION
The ‘fix’ for the ios scrolling bug prevented scrolling of the library. Things need to be refactored.