### PR TITLE
Fix Android scaling

### DIFF
--- a/android/ScratchJr/app/build.gradle
+++ b/android/ScratchJr/app/build.gradle
@@ -13,6 +13,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            debuggable true
+        }
     }
 
     flavorDimensions 'scratchjrversion'

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -365,8 +365,9 @@ public class ScratchJrActivity
         webSettings.setDisplayZoomControls(false);
         webSettings.setLoadWithOverviewMode(false);
         webSettings.setUseWideViewPort(false);
-        // Uncomment to enable remote Chrome debugging on a physical Android device
-        // WebView.setWebContentsDebuggingEnabled(true);
+        if (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
+            WebView.setWebContentsDebuggingEnabled(true);
+        }
 
         // Enable cookie persistence
         CookieManager.setAcceptFileSchemeCookies(true);

--- a/bin/bundle-compile.sh
+++ b/bin/bundle-compile.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 cd ..;
 /usr/local/bin/node ./node_modules/webpack/bin/webpack.js --mode=production
+# /usr/local/bin/node ./node_modules/webpack/bin/webpack.js --mode=development

--- a/src/painteditor/PaintAction.js
+++ b/src/painteditor/PaintAction.js
@@ -13,7 +13,7 @@ import SVGImage from './SVGImage';
 import Camera from './Camera';
 import Events from '../utils/Events';
 import Rectangle from '../geom/Rectangle';
-import {gn, isTablet, isiOS, getIdFor} from '../utils/lib';
+import {gn, isTablet, getIdFor} from '../utils/lib';
 /*
 Type of objects:
 - fixed: Only exists on Assets Backgrounds and can it only be fill (color or camera) or removed
@@ -1130,9 +1130,13 @@ export default class PaintAction {
         var pt2 = Paint.root.createSVGPoint();
         pt2.x = pt.x;
         pt2.y = pt.y;
-        var globalPoint = pt2.matrixTransform(Paint.root.getScreenCTM().inverse());
-        globalPoint.x = globalPoint.x / Paint.currentZoom;
-        globalPoint.y = globalPoint.y / Paint.currentZoom;
+        var screenMatrix = Paint.root.getScreenCTM();
+        var globalPoint = pt2.matrixTransform(screenMatrix.inverse());
+        // screenMatrix should include the currentScale, if it doesn't match, apply scaling
+        if (screenMatrix.a != Paint.currentZoom) {
+            globalPoint.x = globalPoint.x / Paint.currentZoom;
+            globalPoint.y = globalPoint.y / Paint.currentZoom;
+        }
         return globalPoint;
     }
 }


### PR DESCRIPTION
On some newer android devices the screen tranform matrix already includes the current scale. i.e. the matrix looks like:
```
{
    a: scaleX,
    b: 0,
    c: 0,
    d: scaleY,
    e: offsetX,
    f: offsetY
}
```
where both `scaleX`, and `scaleY` are the current zoom. On other devices the scale is always `1`, and we need to apply our own scaling.

I also added the code to automatically allow webview debgging if the buildType is debuggable.  Also, note that you can switch which line is commented out in bundle-compile.sh to get unobfuscated javascript.