### PR TITLE
Fix debugging

### DIFF
--- a/android/ScratchJr/app/build.gradle
+++ b/android/ScratchJr/app/build.gradle
@@ -13,9 +13,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-        debug {
-            debuggable true
-        }
     }
 
     flavorDimensions 'scratchjrversion'

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -365,7 +365,7 @@ public class ScratchJrActivity
         webSettings.setDisplayZoomControls(false);
         webSettings.setLoadWithOverviewMode(false);
         webSettings.setUseWideViewPort(false);
-        if (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
+        if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
 


### PR DESCRIPTION
In [**deprecated** [android gradle plugin docs](https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-BuildConfig) I found the better way to access the buildConfig settings. The [official docs](https://developer.android.com/studio/build/gradle-tips) only show how to define/access custom fields,  not the default values. 

This change in necessary for building the other variants of ScratchJr.