### PR TITLE
Change touchmove handling in editor to prevent scrolling whole window on iOS

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -226,9 +226,6 @@ export default class ScratchJr {
 
     static editorEvents () {
         document.ongesturestart = undefined;
-        document.ontouchmove = function (e) {
-            e.preventDefault();
-        };
         window.ontouchstart = ScratchJr.unfocus;
         if (isTablet) {
             window.ontouchend = undefined;

--- a/src/editor/ui/Scripts.js
+++ b/src/editor/ui/Scripts.js
@@ -93,6 +93,7 @@ export default class Scripts {
             // It seems to have been checking if the drag was on the invisible shadow of the repeat block
             // It's not clear to me why we would want this, and seems functional without it. -- TM
             //if ((ths.owner.blocktype == "repeat") && !hitTest(ths.childNodes[1], pixel)) continue;
+            e.preventDefault();
             Events.startDrag(e, ths, ScriptsPane.prepareToDrag,
                 ScriptsPane.dropBlock, ScriptsPane.draggingBlock, ScriptsPane.runBlock);
             return;


### PR DESCRIPTION
Fixes #217

With help from Paula 

Testing:
- verify still works on Android and iOS
- check anywhere that could scroll:
  - character or backdrop library
  - projects in lobby
  - help documentation
  - blocks palette
  -