### PR TITLE
Require touchscreen in the Android manifest

### DIFF
--- a/android/ScratchJr/app/src/main/AndroidManifest.xml
+++ b/android/ScratchJr/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="true" />
 
     <supports-screens android:requiresSmallestWidthDp="600" />
     <application


### PR DESCRIPTION
Fixes #233

This only changes what the Google Play store considers a compatible device. Testing will be seeing which devices are no longer supported when the apk is uploaded.