### PR TITLE
Don’t export as email message, and be less strict about import requirements

### DIFF
--- a/android/ScratchJr/app/src/main/AndroidManifest.xml
+++ b/android/ScratchJr/app/src/main/AndroidManifest.xml
@@ -40,12 +40,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="file" />
-                <data android:scheme="content" />
                 <data android:mimeType="*/*" />
                 <data android:pathPattern="@string/share_extension_filter" />
+                <!-- These additional pathPattern blocks are to allow for paths with
+                additional periods in them. See:
+                http://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i/8599921 -->
+                <data android:pathPattern="@{`.*\\.` + @string/share_extension_filter}"/>
+                <data android:pathPattern="@{`.*\\..*\\.` + @string/share_extension_filter}"/>
+                <data android:pathPattern="@{`.*\\..*\\..*\\.` + @string/share_extension_filter}"/>
+                <data android:pathPattern="@{`.*\\..*\\..*\\..*\\.` + @string/share_extension_filter}"/>
+                <data android:pathPattern="@{`.*\\..*\\..*\\..*\\..*\\.` + @string/share_extension_filter}"/>
                 <data android:host="*" />
-                <data android:scheme="file" />
-                <data android:scheme="content" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -54,6 +59,16 @@
                 <data android:scheme="file" />
                 <data android:scheme="content" />
                 <data android:mimeType="@string/share_mimetype" />
+                <data android:host="*" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/octet-stream" />
                 <data android:host="*" />
             </intent-filter>
         </activity>

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/JavaScriptDirectInterface.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/JavaScriptDirectInterface.java
@@ -3,8 +3,6 @@ package org.scratchjr.android;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -350,7 +348,7 @@ public class JavaScriptDirectInterface {
     public String scratchjr_cameracheck() {
         return _activity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY) ? "1" : "0";
     }
-    
+
     @JavascriptInterface
     public boolean scratchjr_has_multiple_cameras() {
         return Camera.getNumberOfCameras() > 1;
@@ -582,10 +580,13 @@ public class JavaScriptDirectInterface {
         File tempFile;
 
         String extension;
+        String mimetype;
         if (BuildConfig.APPLICATION_ID.equals("org.pbskids.scratchjr")) {
             extension = ".psjr";
+            mimetype = "application/x-pbskids-scratchjr-project";
         } else {
             extension = ".sjr";
+            mimetype = "application/x-scratchjr-project";
         }
 
         try {
@@ -602,17 +603,18 @@ public class JavaScriptDirectInterface {
         }
 
         final Intent it = new Intent(Intent.ACTION_SEND);
-        it.setType("message/rfc822");
+        it.setType(mimetype);
         it.putExtra(android.content.Intent.EXTRA_EMAIL, new String[] {});
-        it.putExtra(android.content.Intent.EXTRA_SUBJECT, emailSubject);
+        it.putExtra(android.content.Intent.EXTRA_SUBJECT, fileName);
         it.putExtra(android.content.Intent.EXTRA_TEXT, Html.fromHtml(emailBody));
 
         // The stream data is a reference to the temporary file provided by our contentprovider
         it.putExtra(Intent.EXTRA_STREAM,
                 Uri.parse("content://" + ShareContentProvider.AUTHORITY + "/"
                         + fileName));
+        Intent shareIntent = Intent.createChooser(it, null);
 
-        _activity.startActivity(it);
+        _activity.startActivity(shareIntent);
     }
 
     // Analytics

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -310,15 +310,20 @@ public class ScratchJrActivity
         String scheme = projectUri.getScheme();
         Log.i(LOG_TAG, "receiveProject(scheme): " + scheme);
         Log.i(LOG_TAG, "receiveProject(path): " + projectUri.getPath());
-        if (scheme == null || !(scheme.equals(ContentResolver.SCHEME_FILE) || scheme.equals(ContentResolver.SCHEME_CONTENT)) ||
-                !projectUri.getPath().matches(PROJECT_EXTENSION)) {
+
+        // if scheme isn't file or content, skip import
+        if (scheme == null || !(scheme.equals(ContentResolver.SCHEME_FILE) || scheme.equals(ContentResolver.SCHEME_CONTENT))) {
+            return;
+        }
+        // if scheme is file, then skip if filename doesn't have scratchjr project extension
+        if (scheme.equals(ContentResolver.SCHEME_FILE) && !projectUri.getPath().matches(PROJECT_EXTENSION)) {
             return;
         }
         // Read the project one byte at a time into a buffer
         ByteArrayOutputStream projectData = new ByteArrayOutputStream();
         try {
             InputStream is = getContentResolver().openInputStream(projectUri);
-            
+
             byte[] readByte = new byte[1];
             while ((is.read(readByte)) == 1) {
                 projectData.write(readByte[0]);


### PR DESCRIPTION
Fixes #158 
Fixes #253 

Android intent filters are really only designed to work with standard mimetypes (like ‘image/png’). Even if you can share something with a custom mime type, it’s likely to get lost somewhere along the way, from email, or Gdrive, or Files app etc.

Path matching patterns in intent filter only apply to `file` schemes, `content` scheme is likely to be some generated id in temp storage. `content` filters maintly go by mimetype, but as noted above, a custom mimetype has often gone AWOL. Generic application files are usually downloaded as `application/octet-stream`. Basically we have to trust the user not to try to load some other random file into ScratchJr. The import function will fail and give an error message if they do.

Finally, fix the way we’re sharing ScratchJr files. While the button says ‘Share by Email’ for a long time Android has shown a selection of ways to share the file. However, we were setting the mime type as an email message so the saved file would always try to open in an email client instead of ScratchJr.

Most useful SO post about intent filters: https://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension

Basically go look at the Android Source: https://android.googlesource.com/platform/frameworks/base.git/, and then browse to `core/java/android/content/IntentFilter.java`

Things I'm not fixing in this release:
* Share button says 'Share by Email', this has not been true for many releases of Android
* blue ribbon on imported projects is not responsive to the size of the thumbnail and is slightly too big on small devices.

Testing:
Create a project in ScratchJr and export it, common steps:
* tap the yellow tab in the upper right
* click the parents button
* click share by email (yes this still says share by email, no one is available to redesign the button)

Export to email:
* select gmail in the list of apps that appears when you click the share button
* email should have the name of the file as subject, some introductory text in the body, and the project.sjr file as an attachment

Export to file (GDrive and files):
* select Google drive or files app
* filename should be project.sjr (if it doesn't have .sjr extension, please rename when saving for the next part)

Import from email (how this works seems to depend a bit on what version of android you have)
* Tap on attachment in email
* If ScratchJr opens, it should have the project in the lobby with a blue bow (Note if you already have ScratchJr open, you will need to manually go back to the lobby)
* If it says that you don't have anything to open that type of file, download the file and try opening it from the downloads folder

Import from Gdrive:
* Click on file in drive, if prompted to select the app to open the file choose ScratchJr.
* ScratchJr should open with the project in the lobby with a blue bow (again it will not go back to the lobby if it's already open)

Import from files(downloads): 
* Click on the file in the files app, if prompted select ScratchJr as the app to open the file
* project is added to the lobby with a blue bow

Things you should not see:
* when clicking on a file the options for opening it are email apps (e.g. gmail etc), and do not include general file apps or ScratchJr