### PR TITLE
Add more analytics events, and use action as event type

### DIFF
--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -502,10 +502,9 @@ public class ScratchJrActivity
      */
     public void logAnalyticsEvent(String category, String action, String label) {
         Bundle params = new Bundle();
-        params.putString(FirebaseAnalytics.Param.ITEM_ID, action);
         params.putString(FirebaseAnalytics.Param.ITEM_CATEGORY, category);
         params.putString(FirebaseAnalytics.Param.ITEM_NAME, label);
-        _FirebaseAnalytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM, params);
+        _FirebaseAnalytics.logEvent(action, params);
     }
 
     /**

--- a/ios/ScratchJr/src/ViewController.m
+++ b/ios/ScratchJr/src/ViewController.m
@@ -321,9 +321,8 @@ JSContext *js;
 }
 
 -(NSString*) analyticsEvent:(NSString*) category :(NSString*) action :(NSString*) label {
-    [FIRAnalytics logEventWithName:kFIREventViewItem
+    [FIRAnalytics logEventWithName:action
     parameters:@{
-                 kFIRParameterItemID:action,
                  kFIRParameterItemName:label,
                  kFIRParameterItemCategory:category
                  }];

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -536,6 +536,7 @@ export default class ScratchJr {
         inFullscreen = false;
         UI.quitFullScreen();
         onBackButtonCallback.pop();
+        iOS.analyticsEvent('editor', 'full_screen_exited');
         document.body.style.background = 'white';
     }
 

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -381,6 +381,7 @@ export default class ScratchJr {
         ScratchJr.stopStripsFromTop(e);
         ScratchJr.unfocus(e);
         ScratchJr.saveProject(e, ScratchJr.flippage);
+        iOS.analyticsEvent('editor', 'project_editor_close');
     }
 
     static flippage () {

--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -716,6 +716,7 @@ export default class Sprite {
         var sprites = JSON.parse(page.sprites);
         sprites.push(this.id);
         page.sprites = JSON.stringify(sprites);
+        iOS.analyticsEvent('editor', 'text_sprite_create');
         if ((this.str == '') && !whenDone) {
             this.setTextBox();
             this.activateInput();
@@ -805,6 +806,7 @@ export default class Sprite {
         document.body.scrollLeft = 0;
         var form = document.forms.activetextbox;
         var changed = (this.oldvalue != form.typing.value);
+        iOS.analyticsEvent('editor', 'text_sprite_close');
         if (this.noChars(form.typing.value)) {
             this.deleteText(this.oldvalue != '');
         } else {
@@ -889,6 +891,7 @@ export default class Sprite {
         var ti = document.forms.activetextbox.typing;
         gn('textbox').style.visibility = 'visible';
         var me = this;
+        iOS.analyticsEvent('editor', 'text_sprite_open');
         ti.onblur = function () {
             me.unfocusText();
         };

--- a/src/editor/ui/Record.js
+++ b/src/editor/ui/Record.js
@@ -60,6 +60,7 @@ export default class Record {
 
     // Dialog box hide/show
     static appear () {
+        iOS.analyticsEvent('editor', 'record_dialog_open');
         gn('backdrop').setAttribute('class', 'modal-backdrop fade in');
         setProps(gn('backdrop').style, {
             display: 'block'
@@ -71,6 +72,7 @@ export default class Record {
     }
 
     static disappear () {
+        iOS.analyticsEvent('editor', 'record_dialog_close');
         setTimeout(function () {
             gn('backdrop').setAttribute('class', 'modal-backdrop fade');
             setProps(gn('backdrop').style, {
@@ -152,6 +154,7 @@ export default class Record {
     }
 
     static startRecording (filename) {
+        iOS.analyticsEvent('editor', 'start_recording');
         if (parseInt(filename) < 0) {
             // Error in getting record filename - go back to editor
             recordedSound = undefined;
@@ -250,6 +253,7 @@ export default class Record {
 
     // Stop the volume monitor and recording
     static stopRecording (fcn) {
+        iOS.analyticsEvent('editor', 'stop_recording');
         if (timeLimit != null) {
             clearTimeout(timeLimit);
             timeLimit = null;

--- a/src/editor/ui/Thumbs.js
+++ b/src/editor/ui/Thumbs.js
@@ -8,6 +8,7 @@ import Page from '../engine/Page';
 import ScriptsPane from './ScriptsPane';
 import Undo from './Undo';
 import UI from './UI';
+import iOS from '../../iPad/iOS';
 import Events from '../../utils/Events';
 import ScratchAudio from '../../utils/ScratchAudio';
 import {frame, gn, localx, newHTML, scaleMultiplier, getIdFor,
@@ -82,6 +83,7 @@ export default class Thumbs {
         var tb = Thumbs.getType(Thumbs.t, 'pagethumb');
         if (ScratchJr.shaking && (e.target.className == 'deletethumb')) {
             ScratchJr.clearSelection();
+            iOS.analyticsEvent('editor', 'delete_scene');
             ScratchJr.stage.deletePage(tb.owner);
             return;
         }
@@ -376,6 +378,7 @@ export default class Thumbs {
             sc.owner.deactivate();
         }
         ScratchJr.unfocus(e);
+        iOS.analyticsEvent('editor', 'add_scene');
         new Page(getIdFor('page'));
     }
 

--- a/src/editor/ui/UI.js
+++ b/src/editor/ui/UI.js
@@ -761,6 +761,7 @@ export default class UI {
 
     static toggleGrid (b) {
         Grid.hide(b);
+        iOS.analyticsEvent('editor', Grid.hidden ? 'hide_grid' : 'show_grid');
         gn('grid').className = Grid.hidden ? 'gridToggle off' : 'gridToggle on';
     }
 

--- a/src/editor/ui/UI.js
+++ b/src/editor/ui/UI.js
@@ -729,7 +729,7 @@ export default class UI {
         UI.creatTopBarClicky(div, 'go', 'go on', UI.toggleRun);
         UI.creatTopBarClicky(div, 'resetall', 'resetall', UI.resetAllSprites);
         UI.creatTopBarClicky(div, 'full', 'fullscreen', ScratchJr.fullScreen);
-        UI.toggleGrid(true);
+        UI.setShowGrid(false);
     }
 
     static resetAllSprites (e) {
@@ -756,12 +756,12 @@ export default class UI {
 
     static switchGrid () {
         ScratchAudio.sndFX('tap.wav');
-        UI.toggleGrid(!Grid.hidden);
+        UI.setShowGrid(Grid.hidden);
+        iOS.analyticsEvent('editor', Grid.hidden ? 'hide_grid' : 'show_grid');
     }
 
-    static toggleGrid (b) {
-        Grid.hide(b);
-        iOS.analyticsEvent('editor', Grid.hidden ? 'hide_grid' : 'show_grid');
+    static setShowGrid (b) {
+        Grid.hide(!b);
         gn('grid').className = Grid.hidden ? 'gridToggle off' : 'gridToggle on';
     }
 

--- a/src/entry/editor.js
+++ b/src/entry/editor.js
@@ -5,6 +5,7 @@ import Record from '../editor/ui/Record';
 
 export function editorMain () {
     iOS.getsettings(doNext);
+    iOS.analyticsEvent('editor', 'project_editor_open');
     function doNext (str) {
         var list = str.split(',');
         iOS.path = list[1] == '0' ? list[0] + '/' : undefined;

--- a/src/painteditor/Paint.js
+++ b/src/painteditor/Paint.js
@@ -164,8 +164,12 @@ export default class Paint {
         let action = '';
         let label = '';
         // Analytics:
-        // md3: name of the asset, an md5 hash for user generated, filename for library items
-        // sname: is not set for a new character (ignored for backgrounds)
+        // * md3: name of the asset, an md5 hash for user generated, filename for library items
+        // * sname: is not set for a new character (ignored for backgrounds)
+        // log two events:
+        // * paint editor is opened
+        // * type of edit (edit_background, edit_character, new_character)
+        iOS.analyticsEvent('paint_editor', 'paint_editor_open');
         if (bkg) {
             action = 'edit_background';
             label = (md5 in MediaLib.keys) ? md5 : 'user_background';
@@ -352,6 +356,7 @@ export default class Paint {
     }
 
     static close () {
+        iOS.analyticsEvent('paint_editor', 'paint_editor_close');
         saving = true;
         paintFrame.className = 'paintframe disappear';
         frame.style.display = 'block';


### PR DESCRIPTION
Resolves https://github.com/LLK/scratchjr-private/issues/558

### Changes

* Revises ios and android code to send the event's "action" field as its Firebase Analytics event type (instead of every event having the same type, VIEW_ITEM)
* Adds the following analytics events:
    * paint_editor_close
    * paint_editor_open
    * full_screen_exited
    * add_text
    * add_scene
    * delete_scene
    * show_grid
    * hide_grid
    * text_sprite_open
    * text_sprite_close
    * text_sprite_create
    * start_recording, stop_recording 
    * record_dialog_open
    * record_dialog_close
