### PR TITLE
Avoid concatenation in AndroidManifest

### DIFF
--- a/android/ScratchJr/app/src/main/AndroidManifest.xml
+++ b/android/ScratchJr/app/src/main/AndroidManifest.xml
@@ -45,11 +45,10 @@
                 <!-- These additional pathPattern blocks are to allow for paths with
                 additional periods in them. See:
                 http://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i/8599921 -->
-                <data android:pathPattern="@{`.*\\.` + @string/share_extension_filter}"/>
-                <data android:pathPattern="@{`.*\\..*\\.` + @string/share_extension_filter}"/>
-                <data android:pathPattern="@{`.*\\..*\\..*\\.` + @string/share_extension_filter}"/>
-                <data android:pathPattern="@{`.*\\..*\\..*\\..*\\.` + @string/share_extension_filter}"/>
-                <data android:pathPattern="@{`.*\\..*\\..*\\..*\\..*\\.` + @string/share_extension_filter}"/>
+                <data android:pathPattern=".*\\..*\\.sjr"/>
+                <data android:pathPattern=".*\\..*\\..*\\.sjr"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.sjr"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.sjr"/>
                 <data android:host="*" />
             </intent-filter>
             <intent-filter>


### PR DESCRIPTION
Fixes an error that only appears when uploading the APK to Google Play. 

It appears that the Manifest cannot handle concatenation like this. For now, just hardcode the scratchjr extension.

Testing:
Does Google play accept the APK build with this manifest
