### PR TITLE
fix buzz bug when initialOptions missing from settings

### DIFF
--- a/src/utils/InitialOptions.js
+++ b/src/utils/InitialOptions.js
@@ -143,7 +143,7 @@ export default class InitialOptions {
      * Gets next question that needs to be asked
      */
     static nextUnansweredQuestion () {
-        if (!settingsSection || !settingsSection.length) return [];
+        if (!settingsSection || !settingsSection.length) return null;
         var nextUnansweredQuestion = settingsSection.find(function (question) {
             return !InitialOptions.isAnswered(question);
         });


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratchjr/issues/315

### Proposed Changes

fixes buzz bug when initialOptions missing from settings. Previously, the `nextUnansweredQuestion()` function would return `[]` if no questions were found. But `[]` is truthy, not falsy, and index.js would think there is a question to ask!