### PR TITLE
updated method of disabling long press in wkwebkit

### DIFF
--- a/ios/ScratchJr/src/ViewController.m
+++ b/ios/ScratchJr/src/ViewController.m
@@ -118,27 +118,6 @@ NSDate *startDate;
     startDate = [NSDate date];
 }
 
-// Disables iOS 9 webview touch tooltip by disabling the long-press gesture recognizer in subviews
-// Thanks to Rye:
-// http://stackoverflow.com/questions/32687368/how-to-completely-disable-magnifying-glass-for-uiwebview-ios9
-- (void) disableWebViewLongPressGestures:(WKWebView *)webview {
-    for(id subView in webview.subviews) {
-        if([subView isKindOfClass:[UIScrollView class]]) {
-            UIScrollView *scrollView = (UIScrollView *)subView;
-            for(id ssView in scrollView.subviews) {
-                if([NSStringFromClass([ssView class]) isEqualToString:@"UIWebBrowserView"]) {
-                    for(UIGestureRecognizer *gs in [ssView gestureRecognizers]) {
-                        if ([gs isKindOfClass:[UILongPressGestureRecognizer class]])
-                        {
-                            gs.enabled = NO;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 - (void) receiveProject:(NSString *)project{
     NSString *callback = [NSString stringWithFormat:@"OS.loadProjectFromSjr('%@');", project];
     WKWebView *webview = [ViewController webview];
@@ -171,7 +150,7 @@ NSDate *startDate;
 
 - (void) webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     [webview evaluateJavaScript:@"window.tablet = window.webkit.messageHandlers.jsBridge" completionHandler:nil];
-    [self disableWebViewLongPressGestures:webView];
+    [webview evaluateJavaScript:@"document.body.style.webkitTouchCallout='none';" completionHandler:nil];
 
     NSString *debugChoice =[[NSUserDefaults standardUserDefaults] stringForKey:@"debugstate"];
 


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratchjr/issues/328 and Resolves https://github.com/LLK/scratchjr/issues/332

### Proposed Changes

updated method of disabling long press in wkwebkit; disables webkit touch callout, to stop the iOS 13+ WKWebKit image context menu from appearing.

### Before

![Sep-29-2020 13-55-43](https://user-images.githubusercontent.com/3431616/94597767-f889ec00-025b-11eb-8ba2-e88f58e05c3e.gif)

### After

![Sep-29-2020 13-48-56](https://user-images.githubusercontent.com/3431616/94597784-fe7fcd00-025b-11eb-9753-5d1c347dbbb6.gif)
