### PR TITLE
refactor permission request

### DIFF
--- a/android/ScratchJr/app/build.gradle
+++ b/android/ScratchJr/app/build.gradle
@@ -20,10 +20,10 @@ android {
         free {
             dimension = 'scratchjrversion'
             applicationId "org.scratchjr.androidfree"
-            minSdkVersion 19
-            targetSdkVersion 28
-            versionCode 21
-            versionName "1.2.0"
+            minSdkVersion 21
+            targetSdkVersion 29
+            versionCode 22
+            versionName "1.2.11"
         }
     }
 }

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -40,6 +40,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Vector;
 
 /**
  * Main activity for Scratch Jr., consisting of a full-screen landscape WebView.
@@ -103,6 +105,7 @@ public class ScratchJrActivity
     private final int SCRATCHJR_CAMERA_MIC_PERMISSION = 1;
     public int cameraPermissionResult = PackageManager.PERMISSION_DENIED;
     public int micPermissionResult = PackageManager.PERMISSION_DENIED;
+    public int readExtPermissionResult = PackageManager.PERMISSION_DENIED;
 
     /* Firebase analytics tracking */
     private FirebaseAnalytics _FirebaseAnalytics;
@@ -172,33 +175,32 @@ public class ScratchJrActivity
         requestPermissions();
     }
 
-    private void requestExtStoragePermissions() {
-        int readExtPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
-        if (readExtPermissionResult != PackageManager.PERMISSION_GRANTED) {
-            int requestCode = 2;
-            ActivityCompat.requestPermissions(this,
-                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, requestCode);
-        }
-    }
-
+     /*
+    Ask for all permissions when ScratchJr is first launched so that we are not asking a 5-7 year old to give permission
+     */
     public void requestPermissions() {
-        requestExtStoragePermissions();
         cameraPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA);
         micPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO);
+        readExtPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
 
-        String[] desiredPermissions;
-        if (cameraPermissionResult != PackageManager.PERMISSION_GRANTED
-                && micPermissionResult != PackageManager.PERMISSION_GRANTED) {
-            desiredPermissions = new String[]{
-                    Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO
-            };
-        } else if (cameraPermissionResult != PackageManager.PERMISSION_GRANTED) {
-            desiredPermissions = new String[]{Manifest.permission.CAMERA};
-        } else if (micPermissionResult != PackageManager.PERMISSION_GRANTED) {
-            desiredPermissions = new String[]{Manifest.permission.RECORD_AUDIO};
-        } else {
+        if (cameraPermissionResult == PackageManager.PERMISSION_GRANTED
+            && micPermissionResult == PackageManager.PERMISSION_GRANTED
+            && readExtPermissionResult == PackageManager.PERMISSION_GRANTED) {
             return;
         }
+
+        Vector<String> tmp = new Vector<String>(3);
+        if (cameraPermissionResult != PackageManager.PERMISSION_GRANTED) {
+            tmp.add(Manifest.permission.CAMERA);
+        }
+        if (micPermissionResult != PackageManager.PERMISSION_GRANTED) {
+            tmp.add(Manifest.permission.RECORD_AUDIO);
+        }
+        if (readExtPermissionResult != PackageManager.PERMISSION_GRANTED) {
+            tmp.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+        }
+        Object[] tmpArray = tmp.toArray();
+        String[] desiredPermissions = Arrays.copyOf(tmpArray, tmpArray.length, String[].class);
 
         ActivityCompat.requestPermissions(this,
                 desiredPermissions,
@@ -216,6 +218,9 @@ public class ScratchJrActivity
                 }
                 if (permission.equals(Manifest.permission.RECORD_AUDIO)) {
                     micPermissionResult = grantResults[permissionId];
+                }
+                if (permission.equals(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                    readExtPermissionResult = grantResults[permissionId];
                 }
                 permissionId++;
             }


### PR DESCRIPTION
### Resolves
Asks for all permissions at launch

- Resolves #329

### Proposed Changes

On Android at launch ScratchJr will ask for permission to access the camera, microphone, and files. If the user allows permission, that will be saved. If the user denies permission, what happens next will depend somewhat on the version of Android. In general, the user will continue to get asked to permit access unless the user checks the 'do not ask again' in the Android permission dialog.

### Reason for Changes

Instead of asking a child for permission to use the microphone or camera, we hide those parts of the interface when permission is denied. The user was not getting prompted for camera and microphone on new installations, and the default is not to allow microphone or camera.

Permissions:
* camera: needed to be able to fill shapes with the camera in the paint editor
* microphone: needed to be able to record themselves in the sound palette
* file access: needed to be able to import/export scratchjr files.

### Test Coverage

* On first launch (android 6+), the user will be prompted to allow access.
* On subsequent launch, if all permissions where granted, there will be no additional prompt
* On subsequent launch, user will be prompted for any permissions that were not granted, unless they checked off do not ask again
* Android 5.1 and lower the permissions are part of the play store/installation so there is no prompt
