### PR TITLE
change block deletion overlap threshold from .66 to .4

### DIFF
--- a/src/editor/ui/Palette.js
+++ b/src/editor/ui/Palette.js
@@ -498,7 +498,7 @@ export default class Palette {
             (sc.flowCaret.next != null) || (sc.flowCaret.inside != null))) {
             return 'scripts';
         }
-        if (box2.overlapElemBy(box, 0.66) && box2.hitRect({x: el.left / scale, y: el.top / scale})) {
+        if (box2.overlapElemBy(box, 0.4) && box2.hitRect({x: el.left / scale, y: el.top / scale})) {
             return 'palette';
         }
         if (pt && box2.hitRect(pt)) {


### PR DESCRIPTION
### Resolves

Resolves https://github.com/LLK/scratchjr/issues/173 

### Proposed Changes

Moves the threshold for interpreting a block's position as intending for it to be deleted. Previously, the block had to overlap the block library by 66% vertically; but in some layouts there is a bit of a gutter under the blocks palette, and it's hard to reach this threshold. 

This change reduces that number to 40%, which seems to be a better balance. The risk is that users would unintentionally delete blocks, so we don't want to go so far as to make _any_ overlap result in a delete.

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes, or provide the testing steps to verify the change. Screenshots that show the change are also helpful._
