### PR TITLE
fix android import project

### DIFF
--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -334,10 +334,12 @@ public class ScratchJrActivity
         try {
             InputStream is = getContentResolver().openInputStream(projectUri);
 
-            byte[] readByte = new byte[1];
-            while ((is.read(readByte)) == 1) {
-                projectData.write(readByte[0]);
+            byte[] readByte = new byte[1024];
+            int length;
+            while ((length = is.read(readByte)) != -1) {
+                projectData.write(readByte, 0, length);
             }
+            is.close();
         } catch (FileNotFoundException e) {
             Log.i(LOG_TAG, "File not found in project load");
             return;

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -311,7 +311,7 @@ public class ScratchJrActivity
     protected void onNewIntent(Intent it) {
         super.onNewIntent(it);
         if (it != null && it.getData() != null) {
-            projectUri = it.getData();
+            receiveProject(it.getData());
         }
     }
 

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -110,6 +110,11 @@ public class ScratchJrActivity
     /* Firebase analytics tracking */
     private FirebaseAnalytics _FirebaseAnalytics;
 
+    /**
+     * Project uri that need to be imported.
+     */
+    private Uri projectUri = null;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -152,7 +157,7 @@ public class ScratchJrActivity
 
         Intent it = getIntent();
         if (it != null && it.getData() != null) {
-            receiveProject(it.getData());
+            projectUri = it.getData();
         }
 
         _FirebaseAnalytics = FirebaseAnalytics.getInstance(this);
@@ -306,7 +311,7 @@ public class ScratchJrActivity
     protected void onNewIntent(Intent it) {
         super.onNewIntent(it);
         if (it != null && it.getData() != null) {
-            receiveProject(it.getData());
+            projectUri = it.getData();
         }
     }
 
@@ -483,6 +488,10 @@ public class ScratchJrActivity
 
     public void setSplashDone(boolean done) {
         _splashDone = done;
+        if (this.projectUri != null) {
+            receiveProject(this.projectUri);
+        }
+        this.projectUri = null;
     }
 
     /**


### PR DESCRIPTION
### Resolves

Fix #372 

### Proposed Changes

1. Run import project javascript after `OS` is ready.
2. speed up read project file to zip

### Reason for Changes

1. `E/ScratchJr: JavaScript log, :1, Uncaught ReferenceError: OS is not defined`
2. 
```
byte[] readByte = new byte[1];
while ((is.read(readByte)) == 1) {
    projectData.write(readByte[0]);
}
```
Reading a file one byte by one byte is quit inefficient, changed it to 1K, and importing the project with size 2.7M is 100x times faster.

### Test Coverage

[ ] Android: import project
