### PR TITLE
disable drag & drop on images

### DIFF
--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -107,6 +107,9 @@ export default class Sprite {
 
     setCostume (dataurl, fcn) {
         var img = document.createElement('img');
+        img.ondragstart = function () {
+            return false;
+        }
         img.src = dataurl;
         this.img = img;
         // Make a copy that is not affected by zoom transformation

--- a/src/editor/ui/Library.js
+++ b/src/editor/ui/Library.js
@@ -198,6 +198,9 @@ export default class Library {
         img.style.top = (7 * scaleMultiplier) + 'px';
         img.style.position = 'relative';
         img.style.height = (data.height * scale) + 'px';
+        img.ondragstart = function () {
+            return false;
+        }
         if (data.altmd5) {
             IO.getAsset(data.altmd5, drawMe);
         }

--- a/src/lobby/Home.js
+++ b/src/lobby/Home.js
@@ -300,6 +300,9 @@ export default class Home {
         if (md5) {
             IO.getAsset(md5, drawMe);
         }
+        img.ondragstart = function () {
+            return false;
+        }
         function drawMe (url) {
             img.src = url;
         }


### PR DESCRIPTION
### Resolves

Fix #334 

### Proposed Changes

disable drag event for images.

### Reason for Changes

After long-pressing images in a WKWebView on iOS 11 and 12 initiates a Drag & Drop session, see [this stackoverflow link](https://stackoverflow.com/questions/49911060/how-to-disable-ios-11-and-ios-12-drag-drop-in-wkwebview) for more detail.

### Test Coverage

- [x]  Project image on home page
- [x]  user-made assets on library dialog
- [x] sprite image on project page
