### PR TITLE
add max-width and max-height properties for watermark image

### DIFF
--- a/editions/free/src/css/editor.css
+++ b/editions/free/src/css/editor.css
@@ -453,6 +453,11 @@ z-index: 5;
     height: ${css_vh(18.88)};
 }
 
+.watermark img{
+    max-width: 100%;
+    max-height: 100%;
+}
+
 .watermark > canvas{
     position: absolute;
 }


### PR DESCRIPTION
### Resolves

Fix #63 

### Proposed Changes

add `max-width` and `max-height` css properties for watermark image

### Reason for Changes

add `max-width` and `max-height` css properties for watermark image

### Test Coverage

- [ ] android project page
- [ ] ios project page
