### PR TITLE
iOS: get rid of warnings Fix #405

### DIFF
--- a/ios/ScratchJr/src/AppDelegate.m
+++ b/ios/ScratchJr/src/AppDelegate.m
@@ -63,7 +63,7 @@
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
-- (BOOL) application:(UIApplication *)application openURL:(NSURL *) url sourceApplication:(NSString *) sourceApplication annotation:(id) annotation {
+- (BOOL) application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
     if (url) {
         NSString *str = [IO encodeBase64: [[NSData alloc] initWithContentsOfURL:url]];
         [(ViewController*) self.window.rootViewController receiveProject:str];

--- a/ios/ScratchJr/src/ViewController.m
+++ b/ios/ScratchJr/src/ViewController.m
@@ -42,7 +42,6 @@ NSDate *startDate;
     [self reload];
     [self showSplash];
     [IO init: self];
-    [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:NO];
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
     [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
 }


### PR DESCRIPTION
### Resolves

iOS: get rid of deprecated warnings

- Resolves #405 

### Proposed Changes

1. `AppDelegate.m`
2. `ViewController.m`

### Reason for Changes

1. remove useless code
2. replace deprecated functions with new one

### Test Coverage
[ ] iOS: start normally
[ ] XCode: no deprecated warnings
