### PR TITLE
hide gears on init options page

### DIFF
--- a/src/entry/index.js
+++ b/src/entry/index.js
@@ -111,6 +111,7 @@ function indexSetAnalyticsPrefs () {
 function indexLoadStart () {
     indexHideSplash();
     showLogo();
+    showGear();
     gn('gettings').className = 'gettings show';
     gn('startcode').className = 'startcode show';
 
@@ -141,6 +142,14 @@ function hideLogo () {
 function showLogo () {
     gn('catface').className = 'catface show';
     gn('jrlogo').className = 'jrlogo show';
+}
+
+function hideGear () {
+    gn('gear').className = 'gear hide';
+}
+
+function showGear () {
+    gn('gear').className = 'gear show';
 }
 
 function indexAskPlace () {
@@ -227,6 +236,7 @@ function optionTouched (elem) {
 function indexShowQuestion (key) {
     indexHideSplash();
     hideLogo();
+    hideGear();
     var optionType = InitialOptions.optionTypeForKey(key);
     if (optionType === 'place_preference') {
         indexAskPlace();


### PR DESCRIPTION
### Resolves

- Resolves #418 

### Proposed Changes

Hide gear on options page and show gear on the main entry.

### Reason for Changes

Hide the gear button if there is any option none-selected.

### Test Coverage

Run fresh installed app and no gear button shows.
