### PR TITLE
change column-count by optionNum on init options page

### DIFF
--- a/src/entry/index.js
+++ b/src/entry/index.js
@@ -273,6 +273,15 @@ function indexShowQuestion (key) {
             }
             optionNum = optionNum + 1;
         });
+        // iPad mini has the minimum screen size, it can show 13 items in one column
+        // and we use 3 columns as default
+        if (optionNum > 13 * 5) {
+            gn('optionsList').style['column-count'] = 8;
+        } else if (optionNum > 13 * 3) {
+            gn('optionsList').style['column-count'] = 5;
+        } else {
+            gn('optionsList').style['column-count'] = 3;
+        }
         gn('optionsList').className = 'optionsList show';
     }
 }


### PR DESCRIPTION
### Resolves

- Resolves #420 

### Proposed Changes

change `column-count` by `optionNum`

### Reason for Changes

iPad mini has the minimum screen height and it can show 13 items in one column.
According to this, we set `column-count` to 8 if we have more than 65 options,
and set `column-count` to 5 if we have more than 39 options. 

### Test Coverage

- [x] when we have 100 options
- [x] when we have 65 options
