### PR TITLE
touch to click on init options page

### DIFF
--- a/src/entry/index.js
+++ b/src/entry/index.js
@@ -212,7 +212,6 @@ function optionSelected (elem) {
         key = parent.getAttribute('data-key');
         value = parent.getAttribute('data-value');
     }
-    console.log(key, value)
     // if we still don't have a key and value, something is wrong -- just go
     // to lobby
     if (!key && !value) {

--- a/src/entry/index.js
+++ b/src/entry/index.js
@@ -203,7 +203,7 @@ function indexHidePlaceQuestion () {
     gn('usageNoanswer').className = 'usageNoanswer hide';
 }
 
-function optionTouched (elem) {
+function optionSelected (elem) {
     var key = elem.target.getAttribute('data-key');
     var value = elem.target.getAttribute('data-value');
     // sometimes a touch is registered by a child of the relevant parent
@@ -212,6 +212,7 @@ function optionTouched (elem) {
         key = parent.getAttribute('data-key');
         value = parent.getAttribute('data-value');
     }
+    console.log(key, value)
     // if we still don't have a key and value, something is wrong -- just go
     // to lobby
     if (!key && !value) {
@@ -255,7 +256,7 @@ function indexShowQuestion (key) {
             optionElem.setAttribute('data-key', key);
             optionElem.setAttribute('data-value', option);
             optionElem.setAttribute('id', 'option-' + key + '-' + optionNum);
-            optionElem.ontouchend = optionTouched;
+            optionElem.onclick = optionSelected;
             optionsListElem.appendChild(optionElem);
 
             switch (optionType) {


### PR DESCRIPTION
### Resolves

- Resolves #423 

### Proposed Changes

1. change element select trigger event from touch to click
2. rename `optionTouched` to `optionSelected` to reduce miss-understanding

### Reason for Changes

Touch event is too easy to miss-touch

### Test Coverage

- [x] touch an option and move finger out will not trigger selection
- [x] lint without errors
