### PR TITLE
iOS: fix app crash when importing project with text

### DIFF
--- a/ios/ScratchJr/src/IO.m
+++ b/ios/ScratchJr/src/IO.m
@@ -313,7 +313,10 @@ NSMutableDictionary *soundtimers;
         NSDictionary *page = [json valueForKey:name];
         for (NSString *spriteName in [page valueForKey:@"sprites"]) {
             NSDictionary *sprite = [page valueForKey:spriteName];
-            [sprites setValue:sprite forKey:[sprite valueForKey:@"md5"]];
+            NSString *md5 = [sprite valueForKey:@"md5"];
+            if (md5 != nil) {
+                [sprites setValue:sprite forKey:md5];
+            }
         }
     }
     


### PR DESCRIPTION
### Resolves

- Resolves #429 

### Proposed Changes

add md5 nil check

### Reason for Changes

Text in project doesn't have the `md5` field, only process sprite with `md5` field

### Test Coverage

- [x] iOS: import project with text
