### PR TITLE
Fix description background image lost

### DIFF
--- a/editions/free/src/inapp/style/paint.css
+++ b/editions/free/src/inapp/style/paint.css
@@ -385,6 +385,7 @@ body {
 
 #paint-key {
     width: ${css_vh(36.35)};
+    height: ${css_vh(72.53)};
     float: left;
     margin-left: ${css_vh(9.05)};
     background-image: url("../images/keybackground.png");

--- a/src/utils/lib.js
+++ b/src/utils/lib.js
@@ -64,8 +64,12 @@ export function preprocessAndLoad (url) {
  */
 export function preprocessAndLoadCss (baseUrl, url) {
     var cssData = preprocessAndLoad(url);
+    // search for url("../images") pattern
+    cssData = cssData.replace(/url\("/g, 'url(\"' + baseUrl + '/');
+    // search for url('../images') pattern
     cssData = cssData.replace(/url\('/g, 'url(\'' + baseUrl + '/');
-    cssData = cssData.replace(/url\(([^'])/g, 'url(' + baseUrl + '/$1');
+    // search for url(../images) pattern
+    cssData = cssData.replace(/url\(([^'"])/g, 'url(' + baseUrl + '/$1');
 
     const head = document.head;
     let style = document.createElement('style');


### PR DESCRIPTION
### Resolves

- Resolves #433 

### Proposed Changes

1. replace `url("../images")` pattern
2. increase height for `paint-key`

### Reason for Changes

`url("../images")` pattern is also valid css syntax.

### Test Coverage

- [x] interface guide
- [x] paint editor guid
