### PR TITLE
show video after poster image is loaded

### DIFF
--- a/editions/free/src/gettingstarted.html
+++ b/editions/free/src/gettingstarted.html
@@ -18,7 +18,7 @@
 <div class="tutorial" id="tutorialmode">
   <div class="closehelp" id="closeHelp"></div>
   <div class="introvideocontainer">
-      <video class="introvideo" id="myVideo" controls></video>
+      <video class="introvideo" id="myVideo" controls style="display: none;"></video>
   </div>
 </div>
 </body>

--- a/src/entry/gettingstarted.js
+++ b/src/entry/gettingstarted.js
@@ -6,6 +6,12 @@ export function gettingStartedMain () {
     gn('closeHelp').onclick = gettingStartedCloseMe;
     gn('closeHelp').ontouchstart = gettingStartedCloseMe;
     var videoObj = gn('myVideo');
+    videoObj.poster = 'assets/lobby/poster.png';
+    var image = document.createElement('img');
+    image.src = videoObj.poster;
+    image.onload = function () {
+        videoObj.style.display = 'block';
+    };
     if (isiOS) {
         // On iOS we can load from server
         videoObj.src = 'assets/lobby/intro.mp4';
@@ -16,8 +22,6 @@ export function gettingStartedMain () {
             videoObj.src = AndroidInterface.scratchjr_getgettingstartedvideopath();
         }, 1000);
     }
-    videoObj.poster = 'assets/lobby/poster.png';
-
     var urlvars = getUrlVars();
     place = urlvars['place'];
     document.ontouchmove = function (e) {


### PR DESCRIPTION
### Resolves

- Resolves #388 

### Proposed Changes

Show video after poster image is loaded

### Reason for Changes

load poster image first and then show video and its controls

### Test Coverage

- [x] iOS: works well
- [x] Android: works well
