### PR TITLE
Library: no selection after scrolling

### DIFF
--- a/src/editor/ui/Library.js
+++ b/src/editor/ui/Library.js
@@ -301,6 +301,13 @@ export default class Library {
         window.onmousemove = function (evt) {
             clearEvents(evt, tb);
         };
+        window.ontouchmove = function (evt) {
+            tb.ontouchend = undefined;
+            if (timeoutEvent) {
+                clearTimeout(timeoutEvent);
+            }
+            timeoutEvent = undefined;
+        }
         function holdit () {
             var repeat = function () {
                 tb.ontouchend = undefined;


### PR DESCRIPTION
### Resolves

- Resolves #438 

### Proposed Changes

Clear selection event when `touchmove` event detected

### Reason for Changes

1. clear `ontouchend` event
2. clear long touch event

### Test Coverage

1. can select sprite or background
2. long pressing sprite or background calls out delete button
3. select one sprite and start scrolling on the selected on sprite, move up the finger does not select the sprite
