### PR TITLE
Ignore cal variant

### DIFF
--- a/android/ScratchJr/app/src/.gitignore
+++ b/android/ScratchJr/app/src/.gitignore
@@ -1,3 +1,4 @@
 /official
 /arc
 /pbs
+/cal


### PR DESCRIPTION
At some point I will clean up the git ignores - they are in almost every directory and that’s ridiculous. But for now make sure to ignore the cal variant if it shows up in the open source directory structure.

