### PR TITLE
fix padding & margin

### DIFF
--- a/editions/free/src/inapp/style/interface.css
+++ b/editions/free/src/inapp/style/interface.css
@@ -7,8 +7,6 @@ html {
 
 body {
     margin-top: ${css_vh(6)};
-    padding: ${css_vh(2)} ${css_vw(6.05)} ${css_vh(2)};
-    margin: ${css_vh(2.6)} auto;
 }
 
 #content {


### PR DESCRIPTION
### Resolves

- Resolves #459 

### Proposed Changes

left padding for body is wrongly set

### Reason for Changes

keep it the same with `paint.css`

### Test Coverage

- [x] iPad mini 2
- [x] Kindle Fire HD8
