### PR TITLE
Fix bottom padding of the languages selection page

### DIFF
--- a/editions/free/src/css/lobby.css
+++ b/editions/free/src/css/lobby.css
@@ -291,6 +291,7 @@ div.languagebuttons {
     margin: auto;
     margin-top: ${css_vh(4)};
     width: 90%;
+    display: inline-block;
 }
 
 div.localizationselect {
@@ -305,8 +306,8 @@ div.localizationselect {
     /* fontsize based on device vertical height doesn't work on 16:9 aspect Android device, just set fixed size font */
     font-size: 34.5px;
     text-align: center;
-    margin-left: ${css_vw(3)};
-    margin-bottom: ${css_vw(2)};
+    /* 1.68 = (87.89 * 0.9 / 3 - 23) / 2 */
+    margin: 0 ${css_vw(1.68)} ${css_vw(2)};
     padding-top: 2%;
     background-image: linear-gradient(0deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0) 50%, rgba(255,255,255,0.2) 51%);
 }
@@ -465,6 +466,7 @@ div.localizationselect.selected:after {
     margin: ${css_vh(2.6)} auto;
     width: ${css_vw(87.89)};
     height: auto;
+    text-align: center;
 }
 
 


### PR DESCRIPTION
### Resolves

- Resolves #464 

### Proposed Changes

1. make the parent of the buttons `inline-block` and center it
1.  buttons only have left margins which makes it not absolute center in the page, left side of space is slightly larger than the right.

### Reason for Changes

1. the buttons are `float: left`, which impacts the height of it's parent
2. center the buttons: make `margin-left` equals `margin-right`

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.2)
- [x] Amazon Kindle Fire HD 8 (Android 5.1)
- [x] JD Tablet (Android 6.0)
