### PR TITLE
cancel the dragging event if the pointer is outside stage

### DIFF
--- a/src/editor/engine/Stage.js
+++ b/src/editor/engine/Stage.js
@@ -472,6 +472,12 @@ export default class Stage {
             return;
         }
         var pt = this.getStagePt(e);
+        // if pointer is outside stage
+        // cancel the dragging event
+        if (pt.x < 0 || pt.x > this.width || pt.y < 0 || pt.y > this.height) {
+            Events.dragged = false;
+            return;
+        }
         var delta = Vector.diff(pt, this.initialPoint);
         var dist = ScratchJr.inFullscreen ? 15 : 5;
         if (!Events.dragged && (Vector.len(delta) > dist)) {

--- a/src/editor/engine/Stage.js
+++ b/src/editor/engine/Stage.js
@@ -474,8 +474,16 @@ export default class Stage {
         var pt = this.getStagePt(e);
         // if pointer is outside stage
         // cancel the dragging event
-        if (pt.x < 0 || pt.x > this.width || pt.y < 0 || pt.y > this.height) {
+        var threshold = 15;
+        if (
+            pt.x < -threshold
+            || pt.y < -threshold
+            || pt.x > (this.width + threshold)
+            || pt.y > (this.height + threshold)
+        ) {
+            Events.clearEvents();
             Events.dragged = false;
+            Events.dragthumbnail = undefined;
             return;
         }
         var delta = Vector.diff(pt, this.initialPoint);


### PR DESCRIPTION
### Resolves

- Resolves #458

### Proposed Changes

cancel the dragging event if the point is outside stage

### Reason for Changes

From Chris:

> If you start dragging a character on the stage and move your finger off the stage, the character is offset when the touchpoint moves back towards the stage.

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.2)
- [x] Kindle Fire HD 8 (Android 5.1.1)
- [x] JD tablet (Android 6.0)