### PR TITLE
fix .modal.fade position

### DIFF
--- a/editions/free/src/css/editormodal.css
+++ b/editions/free/src/css/editormodal.css
@@ -41,10 +41,6 @@
     margin-right: auto;
 }
 
-.modal.fade {
-    top: -100%;
-}
-
 .modal-body {
     width: 420px;
     height: 113px;


### PR DESCRIPTION
### Resolves

- Resolves #390 

### Proposed Changes

remove `.modal.fade` top attribute

### Reason for Changes

useless and causes the `.modal.fade` div out of the screen

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.2)
- [x] Fire HD 8 (2017) (Android 5)
- [x] JD Tablet (Android 6.0)
