### PR TITLE
Drag sprite with a mouse/trackpad with grid turned on

### DIFF
--- a/src/editor/ui/Grid.js
+++ b/src/editor/ui/Grid.js
@@ -5,7 +5,7 @@
 import ScratchJr from '../ScratchJr';
 import Events from '../../utils/Events';
 import Localization from '../../utils/Localization';
-import {gn, scaleMultiplier, isTablet, newDiv, setProps, newP, newCanvas} from '../../utils/lib';
+import {gn, scaleMultiplier, newDiv, setProps, newP, newCanvas} from '../../utils/lib';
 
 let width = 482;
 let height = 362;

--- a/src/editor/ui/Grid.js
+++ b/src/editor/ui/Grid.js
@@ -31,12 +31,6 @@ export default class Grid {
         Grid.setScaleAndPosition(grid, scaleMultiplier, 47, 75, width, height);
         grid.setAttribute('id', 'livegrid');
         Grid.drawLines(grid, width, height);
-        grid.ontouchstart = function (evt) {
-            ScratchJr.stage.mouseDown(evt);
-        };
-        grid.onmousedown = function (evt) {
-            ScratchJr.stage.mouseDown(evt);
-        };
         Grid.createNumbering(w, h);
         Grid.createCursor();
         Grid.createYcursor();
@@ -75,15 +69,12 @@ export default class Grid {
             ctx.stroke();
             dy += size;
         }
-        if (isTablet) {
-            cnv.ontouchstart = function (evt) {
-                ScratchJr.stage.mouseDown(evt);
-            };
-        } else {
-            cnv.onmousedown = function (evt) {
-                ScratchJr.stage.mouseDown(evt);
-            };
-        }
+        cnv.ontouchstart = function (evt) {
+            ScratchJr.stage.mouseDown(evt);
+        };
+        cnv.onmousedown = function (evt) {
+            ScratchJr.stage.mouseDown(evt);
+        };
     }
 
     static createNumbering (w, h) {
@@ -159,15 +150,12 @@ export default class Grid {
         var cnv = newCanvas(gc, 0, 0, size + 2, size + 2, {
             position: 'absolute'
         });
-        if (isTablet) {
-            cnv.ontouchstart = function (evt) {
-                Grid.mouseDownOnCursor(evt);
-            };
-        } else {
-            cnv.onmousedown = function (evt) {
-                Grid.mouseDownOnCursor(evt);
-            };
-        }
+        cnv.ontouchstart = function (evt) {
+            Grid.mouseDownOnCursor(evt);
+        };
+        cnv.onmousedown = function (evt) {
+            Grid.mouseDownOnCursor(evt);
+        };
         var ctx = cnv.getContext('2d');
         ctx.globalAlpha = 0.5;
         ctx.fillStyle = '#28A5DA';
@@ -175,11 +163,8 @@ export default class Grid {
         ctx.lineWidth = 3;
         ctx.strokeRect(3, 3, size - 6, size - 6);
         ctx.fillRect(3, 3, size - 6, size - 6);
-        if (isTablet) {
-            gc.ontouchstart = Grid.mouseDownOnCursor;
-        } else {
-            gc.onmousedown = Grid.mouseDownOnCursor;
-        }
+        gc.ontouchstart = Grid.mouseDownOnCursor;
+        gc.onmousedown = Grid.mouseDownOnCursor;
     }
 
     static mouseDownOnCursor (e) {

--- a/src/editor/ui/Grid.js
+++ b/src/editor/ui/Grid.js
@@ -31,6 +31,12 @@ export default class Grid {
         Grid.setScaleAndPosition(grid, scaleMultiplier, 47, 75, width, height);
         grid.setAttribute('id', 'livegrid');
         Grid.drawLines(grid, width, height);
+        grid.ontouchstart = function (evt) {
+            ScratchJr.stage.mouseDown(evt);
+        };
+        grid.onmousedown = function (evt) {
+            ScratchJr.stage.mouseDown(evt);
+        };
         Grid.createNumbering(w, h);
         Grid.createCursor();
         Grid.createYcursor();

--- a/src/utils/Events.js
+++ b/src/utils/Events.js
@@ -144,6 +144,9 @@ export default class Events {
     }
 
     static holdit (c, fcn) {
+        if (timeoutEvent) {
+            return;
+        }
         var repeat = function () {
             Events.clearEvents();
             fcn(dragthumbnail);


### PR DESCRIPTION
### Resolves

- Resolves #473 

### Proposed Changes

listen touch and mouse event when grid is on.

### Reason for Changes

When grid on, stage could not listen to mouse/touch event, so bridge the event to stage.

### Test Coverage

- [x] macOS Catalina (10.15.6) with mouse
- [x] iPad mini 2 (iOS 12.5.2)
- [x] Amazon Fire HD 8 (2017) (Android 5.0)
