### PR TITLE
resort sprite, sprite outline, background, delete button zIndex

### DIFF
--- a/src/editor/engine/Page.js
+++ b/src/editor/engine/Page.js
@@ -28,7 +28,8 @@ export default class Page {
         this.sprites = JSON.stringify([]);
         this.bkg = newDiv(this.div, 0, 0, 480, 360, {
             position: 'absolute',
-            background: ScratchJr.stagecolor
+            background: ScratchJr.stagecolor,
+            zIndex: '-10',
         });
         this.bkg.type = 'background';
         ScratchJr.stage.pages.push(this);

--- a/src/editor/engine/Page.js
+++ b/src/editor/engine/Page.js
@@ -28,8 +28,8 @@ export default class Page {
         this.sprites = JSON.stringify([]);
         this.bkg = newDiv(this.div, 0, 0, 480, 360, {
             position: 'absolute',
-            background: ScratchJr.stagecolor,
             zIndex: '-10',
+            background: ScratchJr.stagecolor
         });
         this.bkg.type = 'background';
         ScratchJr.stage.pages.push(this);

--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -44,6 +44,7 @@ export default class Sprite {
         this.div = document.createElement('div');
         setProps(this.div.style, {
             position: 'absolute',
+            zIndex: -1,
             left: '0px',
             top: '0px'
         });
@@ -464,6 +465,7 @@ export default class Sprite {
         this.div.appendChild(this.border);
         setProps(this.border.style, {
             position: 'absolute',
+            zIndex: -2,
             left: '0px',
             top: '0px'
         });


### PR DESCRIPTION
### Resolves

- Resolves #393 

### Proposed Changes

add `zIndex` attribute to background, sprite, sprite outline

### Reason for Changes

`zIndex` is not clearly set which causes random display issue

- background: -10
- sprite: -1
- sprite outline: -2
- delete button: 5

### Test Coverage

- [x] macOS Catalina (10.15.6)
- [x] iPad mini 2 (iOS 12.5.2)
- [x] Amazon Fire HD 8 (2017) Android 5
