### PR TITLE
iOS: open external link in browser

### DIFF
--- a/ios/ScratchJr/src/ViewController.m
+++ b/ios/ScratchJr/src/ViewController.m
@@ -197,6 +197,24 @@ NSDate *startDate;
     });
 }
 
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    // All internal urls are started with file:///, if the url scheme is http or https,
+    // the app is trying to open an external link, we should open it in the browser.
+    // For now, only the PBS edition opens an itunes link in the lobby.
+    // If we are going to support more shemes like opening other apps or ftp etc,
+    // this is the right place to go.
+    NSURL *url = navigationAction.request.URL;
+    NSString *scheme = url.scheme;
+    if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
+        if ([UIApplication.sharedApplication canOpenURL:url]) {
+            [UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];
+        }
+        decisionHandler(WKNavigationActionPolicyCancel);
+        return;
+    }
+    decisionHandler(WKNavigationActionPolicyAllow);
+}
+
 // Sharing controllers - if we later decide to unify, use UIActivityViewController
 
 // Email sharing


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratchjr-private/issues/643

### Proposed Changes

Add support to open external links

### Reason for Changes

If we need to open external link in the browser, we need to make the decision manually.

### Test Coverage

- [x] iOS: PBS edition can open the itunes link
