### PR TITLE
PBS: Fix story-save

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -374,7 +374,12 @@ export default class ScratchJr {
                     Project.prepareToSave(currentProject, onDone);
                 });
             }, true);
-        } else if (ScratchJr.isEditable() && editmode != 'storyStarter' && currentProject && !Project.error && changed) {
+        } else if (ScratchJr.isEditable()
+            && editmode != 'storyStarter'
+            && currentProject
+            && !Project.error
+            && changed
+        ) {
             Project.prepareToSave(currentProject, onDone);
         } else {
             if (onDone) {

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -374,7 +374,7 @@ export default class ScratchJr {
                     Project.prepareToSave(currentProject, onDone);
                 });
             }, true);
-        } else if (ScratchJr.isEditable() && currentProject && !Project.error && changed) {
+        } else if (ScratchJr.isEditable() && editmode != 'storyStarter' && currentProject && !Project.error && changed) {
             Project.prepareToSave(currentProject, onDone);
         } else {
             if (onDone) {

--- a/src/editor/ui/ScriptsPane.js
+++ b/src/editor/ui/ScriptsPane.js
@@ -182,6 +182,8 @@ export default class ScriptsPane {
             var dx = localx(sc, el.left);
             var dy = localy(sc, el.top);
             ScriptsPane.blockDropped(sc, dx, dy);
+            // Start the story if scripts is changed.
+            ScratchJr.storyStart('ScriptsPane.changed');
             break;
         case 'library':
             var thumb = Palette.getHittedThumb(el, gn('spritecc'));


### PR DESCRIPTION
### Resolves

- Resolves #484 

This also fixes #485 

### Proposed Changes

1. Save the project as a user-created one when `editmode` is not `storyStarter`
2. Mark the `storyStarted` as true if changes are made to sprite scripts

### Reason for Changes

1. If the story is changed but not stared, we still should not treat it as a normal project
2. We should save the story project if changes are made to sprite scripts.

### Test Coverage

- [x] iOS: save user-created project normally
- [x] iOS: save sample project when specific changes are made
- [x] Android: save user-created project normally
- [x] Android: save sample project when specific changes are made
