### PR TITLE
refactor saveProject

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -350,42 +350,45 @@ export default class ScratchJr {
     }
 
     static saveProject (e, onDone) {
-        // Only save the sample project if it's changed.
-        if (ScratchJr.isEditable() && editmode == 'storyStarter' && storyStarted && !Project.error && changed) {
-            OS.analyticsEvent('samples', 'story_starter_edited', Project.metadata.name);
-            // Localize sample project names
-            var sampleName = Localization.localizeSampleName(Project.metadata.name);
-            // Get the new project name
-            IO.uniqueProjectName({
-                name: sampleName
-            }, function (jsonData) {
-                var newName = jsonData.name;
-                Project.metadata.name = newName;
-                // Create the new project
-                IO.createProject({
-                    name: newName,
-                    version: version,
-                    mtime: (new Date()).getTime().toString()
-                }, function (md5) {
-                    // Save project data
-                    currentProject = md5;
-                    // Switch out of story-starter mode to avoid creating new projects
-                    editmode = 'edit';
+        if (ScratchJr.isEditable() && !Project.error && changed) {
+            if (editmode != 'storyStarter') {
+                if (currentProject) {
                     Project.prepareToSave(currentProject, onDone);
-                });
-            }, true);
-        } else if (ScratchJr.isEditable()
-            && editmode != 'storyStarter'
-            && currentProject
-            && !Project.error
-            && changed
-        ) {
-            Project.prepareToSave(currentProject, onDone);
-        } else {
-            if (onDone) {
-                onDone();
+                    return;
+                }
+            } else if (storyStarted) {
+                ScratchJr.saveStory(onDone);
+                return;
             }
         }
+        if (onDone) {
+            onDone();
+        }
+    }
+
+    static saveStory (onDone) {
+        OS.analyticsEvent('samples', 'story_starter_edited', Project.metadata.name);
+        // Localize sample project names
+        var sampleName = Localization.localizeSampleName(Project.metadata.name);
+        // Get the new project name
+        IO.uniqueProjectName({
+            name: sampleName
+        }, function (jsonData) {
+            var newName = jsonData.name;
+            Project.metadata.name = newName;
+            // Create the new project
+            IO.createProject({
+                name: newName,
+                version: version,
+                mtime: (new Date()).getTime().toString()
+            }, function (md5) {
+                // Save project data
+                currentProject = md5;
+                // Switch out of story-starter mode to avoid creating new projects
+                editmode = 'edit';
+                Project.prepareToSave(currentProject, onDone);
+            });
+        }, true);
     }
 
     static saveAndFlip (e) {

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -366,6 +366,10 @@ export default class ScratchJr {
         }
     }
 
+    /**
+     * Save the story as a new project so that the user can
+     * continue to edit or share it in the future.
+     */
     static saveStory (onDone) {
         OS.analyticsEvent('samples', 'story_starter_edited', Project.metadata.name);
         // Localize sample project names


### PR DESCRIPTION
### Resolves

- Resolves #493 

### Proposed Changes

Refactor `ScratchJr.saveProject`, move story saving function out of `saveProject`

### Reason for Changes

Make `ScratchJr.saveProject` more readable

### Test Coverage

- [x] iOS: able to save project
- [x] iOS: able to save story
- [x] Android: able to save normal project
- [x] Android: able to save story project
- [x] code lint
