### PR TITLE
Android: Fix soft keyboard hides too quickly

### DIFF
--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -545,12 +545,20 @@ public class ScratchJrActivity
 
     /**
      * Height of the status bar at the top of the screen
+     * We should always know the status bar height even if
+     * the status bar is not visible at all.
+     * See https://stackoverflow.com/a/14213035
      */
     private int getStatusBarHeight() {
-        Rect rectangle= new Rect();
-        Window window= getWindow();
-        window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
-        int result = rectangle.top;
+        int result = 0;
+        int resourceId = getResources().getIdentifier(
+            "status_bar_height",
+            "dimen",
+            "android"
+        );
+        if (resourceId > 0) {
+            result = getResources().getDimensionPixelSize(resourceId);
+        }
         return result;
     }
 
@@ -616,7 +624,11 @@ public class ScratchJrActivity
                                 animator.start();
                                 _currentAnimator = animator;
                             }
-                        } else if (currentVisibleHeight > _priorVisibleHeight) {
+                        } else if (currentVisibleHeight > _priorVisibleHeight + getStatusBarHeight()) {
+                            // The status bar will be hidden ONE second after the keyboard is shown,
+                            // on some devices like SM-T280, the `currentVisibleHeight` will increase
+                            // by the status bar height, we don't want it to infect the keyboard.
+                            // -- Yueyu Zhao
                             // Keyboard probably just became hidden
 
                             // Reset pan


### PR DESCRIPTION
### Resolves

- Resolves #494 

### Proposed Changes

1. always get status bar's height even if the status bar is hidden
2. add `currentVisibleHeight` change threshold of status bar height 

### Reason for Changes

The status bar will be hidden ONE second after the keyboard is shown,
on some devices like SM-T280, the `currentVisibleHeight` will increase
by the status bar height, we don't want it to infect the keyboard.

### Test Coverage

- SM-T280 (Android 5.1.1)
  - [x] text sprite
  - [x] say block text
  - [x] sprite name
  - [x] project name

- Kindle Fire HD (Android 5.1)
  - [x] text sprite
  - [x] say block text
  - [x] sprite name
  - [x] project name

- JD Tablet (Android 6.0)
  - [x] text sprite
  - [x] say block text
  - [x] sprite name
  - [x] project name
