### PR TITLE
Set screen matrix scale to Paint.currentZoom

### DIFF
--- a/src/painteditor/PaintAction.js
+++ b/src/painteditor/PaintAction.js
@@ -1139,12 +1139,10 @@ export default class PaintAction {
         pt2.x = pt.x;
         pt2.y = pt.y;
         var screenMatrix = Paint.root.getScreenCTM();
+        // screenMatrix should include the currentScale, apply scaling
+        screenMatrix.a = Paint.currentZoom;
+        screenMatrix.d = Paint.currentZoom;
         var globalPoint = pt2.matrixTransform(screenMatrix.inverse());
-        // screenMatrix should include the currentScale, if it doesn't match, apply scaling
-        if (screenMatrix.a != Paint.currentZoom) {
-            globalPoint.x = globalPoint.x / Paint.currentZoom;
-            globalPoint.y = globalPoint.y / Paint.currentZoom;
-        }
         return globalPoint;
     }
 }


### PR DESCRIPTION
### Resolves

- Resolves #282 

### Proposed Changes

Set screen matrix scale to `Paint.currentZoom`

### Reason for Changes

On some devices the scale of `screenMatrix` is always `1`, and we need to apply the scale to `Paint.currentZoom`.
If we need to change the scale of the transform, we should not do the math with the result directly. 
For instance, let's say we have a matrix like 
```
{
  a: 1, 
  b: 0,
  c: 0,
  d: 1,
  e: 100,
  f: 100
}
``` 
and a point `{x: 10, y: 10}`, after the transform, we will get the point `{x: 110, y: 110}`. If we need to set the scale to other values, let's say `2`, if we multiply the result by scale `2`, we will get `{x: 220, y: 220}` which is not the correct answer. Otherwise, we should set the matrix to 
```
{
  a: 2, 
  b: 0,
  c: 0,
  d: 2,
  e: 100,
  f: 100
}
```
and after the transform we will get `{x: 120, y: 120}`.

Although the sample calculation above is not 100% same with the one we did in the software, but the logic is the same. 

### Test Coverage

- [x] iPad mini 4 (iOS 14.1)
- [x] iPad Pro 4th generation (12.9 inch) (iOS 14.1)
- [x] SM-T280 (Android 5.1.1)
- [x] Kindle Fire HD 8 (Android 5.1)
- [x] JD Tablet (Android 6.0)
