### PR TITLE
Fix clone svg element null pointer

### DIFF
--- a/src/painteditor/SVGTools.js
+++ b/src/painteditor/SVGTools.js
@@ -805,6 +805,9 @@ export default class SVGTools {
             var g = SVGTools.createGroup(p, getIdFor('group'));
             for (var i = 0; i < elem.childElementCount; i++) {
                 var shape = SVGTools.getClonedElement(g, elem.childNodes[i]);
+                if (!shape) {
+                    continue;
+                }
                 old.push(elem.childNodes[i].id);
                 newlist.push(shape.id);
                 if (elem.childNodes[i].getAttribute('id').indexOf('Border') > -1) {


### PR DESCRIPTION
### Resolves

- Resolves #499 
- Resolves https://github.com/LLK/scratchjr-private/issues/646

### Proposed Changes

Skip to continue processing null element.

### Reason for Changes

Sometimes the cloned element is null and should not be processed.

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.2) 
- [x] SM T280 (Android 5.1.1)
- [x] Kindle Fire HD 8 (Android 5.1)
