### PR TITLE
Handle Brazilian Portuguese

### DIFF
--- a/src/utils/Localization.js
+++ b/src/utils/Localization.js
@@ -89,9 +89,9 @@ export default class Localization {
             currentLocale = localizationCookie;
         }
         var topLevel = currentLocale.split('-')[0];
-        if (topLevel === 'zh') {
+        if (topLevel === 'zh' || topLevel === 'pt') {
             // need to handle locale in addition to language code for Chinese,
-            // ensure it's lower case to match filename
+            // and Portuguese, ensure it's lower case to match filename
             topLevel = currentLocale.toLowerCase();
         }
 


### PR DESCRIPTION
We need special handling for languages where we use locale (zh and pt), pt was missing from the code.

### Resolves

- Resolves #506 

### Proposed Changes

checks for the language code `pt` in addition to `zh` and lowercases the result so that the correct file will be loaded.

### Reason for Changes
Looks like we just forgot to update the code that looks for locale in addition to language when we added Brazilian portuguese.

### Test Coverage
Manually tested.
