### PR TITLE
Don't remove shape when cancelling camera fill

### DIFF
--- a/src/painteditor/Paint.js
+++ b/src/painteditor/Paint.js
@@ -837,7 +837,9 @@ export default class Paint {
         cc.onmousedown = Paint.closeCameraMode;
     }
 
-    static closeCameraMode () {
+    static closeCameraMode (evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
         ScratchAudio.sndFX('exittap.wav');
         Camera.close();
         Paint.selectButton('select');


### PR DESCRIPTION
### Resolves

- Resolves #511 

### Proposed Changes

stop the triggered touch/mouse events to continue

### Reason for Changes

The event of Undo button in the paint editor is wrongly triggered if the user cancel camera fill

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.1)
- [x] Kindle Fire HD 8 (Android 5.1)
