### PR TITLE
Don't close the text form when click on the textbox

### DIFF
--- a/src/editor/ui/UI.js
+++ b/src/editor/ui/UI.js
@@ -952,8 +952,8 @@ export default class UI {
     static createFormForText (p) {
         var tf = newHTML('div', 'pagetext off', p);
         tf.setAttribute('id', 'textbox');
-        // If the textbox is click or touched, the input may lost focus,
-        // and it may cause the text form miss closed.
+        // If the textbox background is clicked or touched, the input loses focus,
+        // which causes the text input to close unexpectedly 
         var eatEvent = function (e) {
             e.stopPropagation();
             e.preventDefault();

--- a/src/editor/ui/UI.js
+++ b/src/editor/ui/UI.js
@@ -952,11 +952,14 @@ export default class UI {
     static createFormForText (p) {
         var tf = newHTML('div', 'pagetext off', p);
         tf.setAttribute('id', 'textbox');
-        if (isAndroid) {
-            tf.onmousedown = function (e) {
-                e.preventDefault();
-            };
-        }
+        // If the textbox is click or touched, the input may lost focus,
+        // and it may cause the text form miss closed.
+        var eatEvent = function (e) {
+            e.stopPropagation();
+            e.preventDefault();
+        };
+        tf.ontouchstart = eatEvent;
+        tf.onmousedown = eatEvent;
         var activetb = newHTML('form', 'pageform', tf);
         activetb.name = 'activetextbox';
         activetb.id = 'myform';


### PR DESCRIPTION
### Resolves

- Resolves #508 

### Proposed Changes

Ignore the events when touch/click on the textbox

### Reason for Changes

When editing or creating text sprite, the text box will be closed if the user clicked on the blue area.

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.1)
- [x] Kindle Fire HD 8 (Android 5.1)
