### PR TITLE
iOS: scroll up a little bit if the textbox is on the bottom half of the screen

### DIFF
--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -915,7 +915,9 @@ export default class Sprite {
         } else {
             // On iOS if the bottom of the textbox is lower than half of the screen
             // the color and font size menu may be covered by the keyboard
-            if (gn('textbox').offsetTop + gn('textbox').offsetHeight > WINDOW_INNER_HEIGHT / 2) {
+            // 0.45 is a magic number and we should compare the bottom Y of the textbox VS
+            // WINDOW_INNER_HEIGHT substract the keyboard height.
+            if (gn('textbox').offsetTop + gn('textbox').offsetHeight > WINDOW_INNER_HEIGHT * 0.45) {
                 // scroll up a little more than the textbox height
                 // to show the color menu and font size menu.
                 window.scroll(0, gn('textbox').offsetHeight * 1.2);

--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -913,6 +913,13 @@ export default class Sprite {
                 me.unfocusText();
             });
         } else {
+            // On iOS if the bottom of the textbox is lower than half of the screen
+            // the color and font size menu may be covered by the keyboard
+            if (gn('textbox').offsetTop + gn('textbox').offsetHeight > WINDOW_INNER_HEIGHT / 2) {
+                // scroll up a little more than the textbox height 
+                // to show the color menu and font size menu.
+                window.scroll(0, gn('textbox').offsetHeight * 1.2);
+            }
             if (isTablet) {
                 ti.focus();
             } else {

--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -916,7 +916,7 @@ export default class Sprite {
             // On iOS if the bottom of the textbox is lower than half of the screen
             // the color and font size menu may be covered by the keyboard
             if (gn('textbox').offsetTop + gn('textbox').offsetHeight > WINDOW_INNER_HEIGHT / 2) {
-                // scroll up a little more than the textbox height 
+                // scroll up a little more than the textbox height
                 // to show the color menu and font size menu.
                 window.scroll(0, gn('textbox').offsetHeight * 1.2);
             }

--- a/src/editor/engine/Sprite.js
+++ b/src/editor/engine/Sprite.js
@@ -28,7 +28,7 @@ import {newHTML, newDiv, newP, gn,
     setCanvasSizeScaledToWindowDocumentHeight,
     DEGTOR, getIdFor, setProps, isTablet, isiOS,
     isAndroid, fitInRect, scaleMultiplier, setCanvasSize,
-    globaly, globalx, rgbToHex} from '../../utils/lib';
+    globaly, globalx, rgbToHex, WINDOW_INNER_HEIGHT} from '../../utils/lib';
 
 export default class Sprite {
     constructor (attr, whenDone) {


### PR DESCRIPTION
### Resolves

- Resolves #474 

### Proposed Changes

Scroll up if the bottom of textbox is on the bottom half of the screen

### Reason for Changes

On some specific position, the textbox for text sprites are not shown fully on iOS

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.2)
- [x] iPad Pro 4th generation (12.9 inch) (iOS 14.1)
