### PR TITLE
iOS: disable PictureInPicture video play mode

### DIFF
--- a/ios/ScratchJr/src/ViewController.m
+++ b/ios/ScratchJr/src/ViewController.m
@@ -50,6 +50,7 @@ NSDate *startDate;
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
     config.allowsInlineMediaPlayback = true;
     config.allowsAirPlayForMediaPlayback = true;
+    config.allowsPictureInPictureMediaPlayback = false;
     [config.preferences setValue:@YES forKey:@"allowFileAccessFromFileURLs"];
 
     WKUserContentController *controller = [[WKUserContentController alloc] init];


### PR DESCRIPTION
### Resolves

- Resolves #510 

### Proposed Changes

Disable PictureInPicture on iOS

### Reason for Changes

The PictureInPicture feature is not needed

### Test Coverage

- [x] iPad mini 2 (iOS 12.5.2)
- [x] iPad Pro 4th (iOS 14.1)
