### PR TITLE
Stop the scripts if the block arg is clicked

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -609,6 +609,9 @@ export default class ScratchJr {
     static editArg (e, ti) {
         e.preventDefault();
         e.stopPropagation();
+        // When the user try to change the block argument of a running script,
+        // its behavior or location is unpredictable and may cause other issues.
+        // See https://github.com/LLK/scratchjr/issues/509 for more details
         ScratchJr.stopStrips();
         if (ti && ti.owner.isText()) {
             ScratchJr.textClicked(e, ti);

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -609,6 +609,7 @@ export default class ScratchJr {
     static editArg (e, ti) {
         e.preventDefault();
         e.stopPropagation();
+        ScratchJr.stopStrips();
         if (ti && ti.owner.isText()) {
             ScratchJr.textClicked(e, ti);
         } else {


### PR DESCRIPTION
### Resolves

- Resolves #509 

### Proposed Changes

Stop the scripts if the block arg is clicked

### Reason for Changes

When the user try to change the block argument of a running script, its behavior or location is unpredictable and may cause other issues.

### Test Coverage

- [x] iPad mini 2(iOS 12.5.2)
- [x] Kindle Fire HD 8 (Android 5.1)
