### PR TITLE
robust improvement: fix invalid input

### DIFF
--- a/src/editor/blocks/BlockArg.js
+++ b/src/editor/blocks/BlockArg.js
@@ -206,6 +206,9 @@ export default class BlockArg {
             return;
         }
         this.argValue = val;
+        if (this.argType == 'n' && isNaN(Number(val))) {
+            this.argValue = 0;
+        }
         this.input.textContent = val;
     }
 

--- a/src/editor/ui/UI.js
+++ b/src/editor/ui/UI.js
@@ -953,7 +953,7 @@ export default class UI {
         var tf = newHTML('div', 'pagetext off', p);
         tf.setAttribute('id', 'textbox');
         // If the textbox background is clicked or touched, the input loses focus,
-        // which causes the text input to close unexpectedly 
+        // which causes the text input to close unexpectedly
         var eatEvent = function (e) {
             e.stopPropagation();
             e.preventDefault();


### PR DESCRIPTION
### Resolves

- Resolves #509 

### Proposed Changes

When the block argument needs a number, set it to 0 if it's invalid.

### Reason for Changes

When editing running blocks, the single `-` sign is not processed properly. 

### Test Coverage

- [x] iPad mini 2 (iOS 12.5)
- [x] Kindle Fire HD8 (Android 5.1)
