### PR TITLE
save sprite name empty if it's empty

### DIFF
--- a/src/painteditor/Paint.js
+++ b/src/painteditor/Paint.js
@@ -669,7 +669,7 @@ export default class Paint {
         ScratchJr.activeFocus = undefined;
         var spr = ScratchJr.getSprite();
         var ti = e.target;
-        var val = ScratchJr.validate(ti.value, spr.name);
+        var val = ScratchJr.validate(ti.value, '');
         ti.value = val.substring(0, ti.maxLength);
         ScratchJr.storyStart('Paint.nameBlur');
     }
@@ -1417,10 +1417,7 @@ export default class Paint {
     }
 
     static getLoadType (sid, cid) {
-        if (!cid) {
-            return 'none';
-        }
-        if (sid && cid) {
+        if (sid) {
             return 'modify';
         }
         return 'add';


### PR DESCRIPTION
### Resolves

- Resolves #503 

### Proposed Changes

save sprite name empty if it's empty

### Reason for Changes

If users set the sprite name to empty, the old name will get back.

### Test Coverage

- [ ] macOS 10.15
- [ ] iPad mini 2 (iOS 12.5)
- [ ] Kindle Fire HD 8 (Android 5.1)
