### PR TITLE
iOS: escape single quote in project title

### DIFF
--- a/ios/ScratchJr/src/JsBridge.m
+++ b/ios/ScratchJr/src/JsBridge.m
@@ -163,6 +163,7 @@
     NSDictionary* metadata = request.params[1];
     NSString* name = request.params[2];
     NSString * fullName = [IO createZipForProject:projectData :metadata :name];
+    fullName = [fullName stringByReplacingOccurrencesOfString:@"'" withString:@"\\'"];
     [request callback:fullName];
 }
 


### PR DESCRIPTION
### Resolves

- Resolves #430 

### Proposed Changes

Escape single quote in project title when sharing 

### Reason for Changes

iOS calls back Javascript strings are wrapped with single code, if the callback result contains single code, it will break the string.

### Test Coverage

- [x]  PBS edition on iPad mini 2 (iOS 12.5)
- [x] Official edition on iPad mini 2 (iOS 12.5)
