### PR TITLE
Revert "Remove unnecessary request for External Storage"

### DIFF
--- a/android/ScratchJr/app/src/main/AndroidManifest.xml
+++ b/android/ScratchJr/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrActivity.java
@@ -183,9 +183,11 @@ public class ScratchJrActivity
     public void requestPermissions() {
         cameraPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA);
         micPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO);
+        readExtPermissionResult = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
 
         if (cameraPermissionResult == PackageManager.PERMISSION_GRANTED
-            && micPermissionResult == PackageManager.PERMISSION_GRANTED) {
+            && micPermissionResult == PackageManager.PERMISSION_GRANTED
+            && readExtPermissionResult == PackageManager.PERMISSION_GRANTED) {
             return;
         }
 
@@ -195,6 +197,9 @@ public class ScratchJrActivity
         }
         if (micPermissionResult != PackageManager.PERMISSION_GRANTED) {
             tmp.add(Manifest.permission.RECORD_AUDIO);
+        }
+        if (readExtPermissionResult != PackageManager.PERMISSION_GRANTED) {
+            tmp.add(Manifest.permission.READ_EXTERNAL_STORAGE);
         }
         Object[] tmpArray = tmp.toArray();
         String[] desiredPermissions = Arrays.copyOf(tmpArray, tmpArray.length, String[].class);
@@ -215,6 +220,9 @@ public class ScratchJrActivity
                 }
                 if (permission.equals(Manifest.permission.RECORD_AUDIO)) {
                     micPermissionResult = grantResults[permissionId];
+                }
+                if (permission.equals(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                    readExtPermissionResult = grantResults[permissionId];
                 }
                 permissionId++;
             }


### PR DESCRIPTION
Reverts LLK/scratchjr#486
Fixes #526 

While not required on all versions of Android, it is required on some, so we need to ask for permission all the time.