### PR TITLE
Android: check item path before unzipping

### DIFF
--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/IOManager.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/IOManager.java
@@ -284,7 +284,10 @@ public class IOManager {
         }
         File tempDir = new File(activity.getCacheDir() + File.separator + UUID.randomUUID().toString());
         tempDir.mkdir();
-        List<String> entries = ScratchJrUtil.unzip(activity.getContentResolver().openInputStream(uri), tempDir.getPath());
+        List<String> entries = ScratchJrUtil.unzip(
+            activity.getContentResolver().openInputStream(uri),
+            tempDir.getCanonicalPath()
+        );
         if (entries.isEmpty()) {
             Log.e(LOG_TAG, "no entries found");
             // no files

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrUtil.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrUtil.java
@@ -195,7 +195,7 @@ public class ScratchJrUtil {
                 // we need to confirm it will only extract to the expected folder.
                 // For more details see https://support.google.com/faqs/answer/9294009
                 if (!unzipFile.getCanonicalPath().startsWith(toPath)) {
-                    continue;
+                    throw new SecurityException("Unsafe file path found and unzipping will not be allowed for security purposes.");
                 }
                 if (ze.isDirectory()) {
                     if(!unzipFile.isDirectory()) {

--- a/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrUtil.java
+++ b/android/ScratchJr/app/src/main/java/org/scratchjr/android/ScratchJrUtil.java
@@ -190,6 +190,13 @@ public class ScratchJrUtil {
             while ((ze = zin.getNextEntry()) != null) {
                 String path = toPath + File.separator + ze.getName();
                 File unzipFile = new File(path);
+                // Zip files can contain an entry (file or directory) having path
+                // traversal characters ("../") in its name. Before unzipping,
+                // we need to confirm it will only extract to the expected folder.
+                // For more details see https://support.google.com/faqs/answer/9294009
+                if (!unzipFile.getCanonicalPath().startsWith(toPath)) {
+                    continue;
+                }
                 if (ze.isDirectory()) {
                     if(!unzipFile.isDirectory()) {
                         unzipFile.mkdirs();


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/LLK/scratchjr-private/issues/671

### Proposed Changes

Check item path before unzipping

### Reason for Changes

Please see the original issue.

### Test Coverage

- [x] Galaxy Tab A (Android 5.1.1)
- [x] Kindle Fire HD 8 (Android 5.1)
- [x] JD Tablet (Android 6.0)
