### PR TITLE
update shared ribbon styles

### DIFF
--- a/editions/free/src/css/thumbs.css
+++ b/editions/free/src/css/thumbs.css
@@ -156,14 +156,15 @@
 }
 
 .share {
-    position: relative;
-    top: ${css_vh(-22.14)};
-    right: ${css_vw(-12.7)};
+    position: absolute;
+    top: calc(2.75vh  + ${14 * scaleMultiplier}px);
+    left: calc(16.75vh + ${5 * scaleMultiplier}px);
     z-index: 5;
-    width: ${css_vw(5.47)};
-    height: ${css_vh(6.51)};
+    width: 6.72vh;
+    height: 6vh;
     background: url('../assets/ui/share-bow.svg');
     background-size: 101%;
+    background-repeat: no-repeat;
     visibility: hidden;
 }
 
@@ -171,9 +172,9 @@
     background-color: #1dafed;
     border: 3px solid #fff;
     height: ${css_vh(1.57)};
-    width: ${css_vw(18.75)};
-    position: relative;
-    top: ${css_vh(-27.34)};
+    width: 25vh;
+    position: absolute;
+    top: calc(4vh +  ${14 * scaleMultiplier}px);
     z-index: 4;
     visibility: hidden;
 }
@@ -182,10 +183,10 @@
     background-color: #1dafed;
     border: 3px solid #fff;
     width: ${css_vw(1.17)};
-    height: ${css_vh(19)};
-    position: relative;
-    top: ${css_vh(-32.81)};
-    right: ${css_vw(-14.65)};
+    height: 18.75vh;
+    position: absolute;
+    top: ${14 * scaleMultiplier}px;
+    left: calc(18.75vh + ${5 * scaleMultiplier}px);
     z-index: 4;
     visibility: hidden;
 }


### PR DESCRIPTION
### Resolves

- Resolves #16 

### Proposed Changes

Update shared ribbon styles

### Reason for Changes

The project thumb size are in `vh` unit, which is 4:3. To comply with the thumb image, the shared ribbon and bow should also be in `vh` unit. Also the `position` of `projectthumb` is `relative`, so we can use `position: absolute;` to position ribbon and bow safely.

Since we are not supporting Android 4.4, we can use `vh` and `calc` in our stylesheet files.

- [Can I use ViewPort Units](https://caniuse.com/viewport-units)
- [Can I use calc](https://caniuse.com/?search=calc)

### Test Coverage

- [x] iPad mini 2 (iOS 12.5) (4:3)
- [x] Galaxy Tab A (Android 5.1) (16:9)
- [x] Kindle Fire HD8 (Android 5.1) (16:9)
- [x] JD Tablet (Android 6.0) (4:3)
- [x] iPad mini 6 (iOS 15) (16:9) (simulator)
